### PR TITLE
Increased ECS(api_slow) threshold to 600

### DIFF
--- a/mp-prod/conf.d/flag_metrics.yaml
+++ b/mp-prod/conf.d/flag_metrics.yaml
@@ -414,10 +414,10 @@ flag_metrics:
       - name: "production_eu-de"
       - name: "production_eu-nl"
 
-  - name: "api_slow"
+  - name: "api_slow_600"
     service: "compute"
     template:
-      name: "api_slow"
+      name: "api_slow_600"
     environments:
       - name: "production_eu-de"
       - name: "production_eu-nl"
@@ -438,10 +438,10 @@ flag_metrics:
       - name: "production_eu-de"
       - name: "production_eu-nl"
 
-  - name: "api_slow"
+  - name: "api_slow_600"
     service: "ecs"
     template:
-      name: "api_slow"
+      name: "api_slow_600"
     environments:
       - name: "production_eu-de"
       - name: "production_eu-nl"

--- a/mp-prod/conf.d/health_metrics.yaml
+++ b/mp-prod/conf.d/health_metrics.yaml
@@ -36,13 +36,13 @@ health_metrics:
     category: compute
     metrics:
       - ecs.api_down
-      - ecs.api_slow
+      - ecs.api_slow_600
       - ecs.api_success_rate_low
       - compute.api_down
-      - compute.api_slow
+      - compute.api_slow_600
       - compute.api_success_rate_low
     expressions:
-      - expression: "ecs.api_slow || compute.api_slow || ecs.api_success_rate_low || compute.api_success_rate_low"
+      - expression: "ecs.api_slow_600 || compute.api_slow_600 || ecs.api_success_rate_low || compute.api_success_rate_low"
         weight: 1
       - expression: "ecs.api_down || compute.api_down"
         weight: 2

--- a/mp-prod/conf.d/metric_templates.yaml
+++ b/mp-prod/conf.d/metric_templates.yaml
@@ -20,6 +20,10 @@ metric_templates:
     query: "consolidateBy(aggregate(stats.timers.openstack.api.$environment.*.$service.*.*.*.mean, 'average'), 'average')"
     op: "gt"
     threshold: 300
+  api_slow_600:
+    query: "consolidateBy(aggregate(stats.timers.openstack.api.$environment.*.$service.*.*.*.mean, 'average'), 'average')"
+    op: "gt"
+    threshold: 600
   api_failed:
     query: "consolidateBy(aggregate(stats.counters.openstack.api.$environment.*.$service.*.*.failed.count, 'count'), 'sum')"
     op: "gt"


### PR DESCRIPTION
Fixed/Increased the ECS flag threshold to 600 for api_slow. @vladimirhasko kindly review the changes and let me know if anything else needs to be changed or if we are good to go! Thanks