### PR TITLE
On SD2, Category renamed to "Network" and  attributes named "Private Link Access Service"

### DIFF
--- a/sdb_ch2/catalog.yaml
+++ b/sdb_ch2/catalog.yaml
@@ -60,7 +60,7 @@ components:
   name: Cloud Trace Service
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: dc
   name: Direct Connect
@@ -96,7 +96,7 @@ components:
 #   name: Distributed Message Service
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: dns
   name: Domain Name Service
@@ -120,13 +120,13 @@ components:
   name: Elastic Cloud Server
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: eip
   name: Elastic IP
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: elb
   name: Elastic Load Balancing
@@ -186,7 +186,7 @@ components:
 #   name: Map Reduce Service
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: natgw
   name: NAT Gateway
@@ -204,7 +204,7 @@ components:
 #   name: GaussDB (openGauss)
 
 # - attributes:
-#     category: Networking
+#     category: Network
 #     region: EU-CH2
 #     type: plas
 #   name: Private Link Access
@@ -246,7 +246,7 @@ components:
   name: Simple Message Notification
 
 # - attributes:
-#     category: Networking
+#     category: Network
 #     region: EU-CH2
 #     type: smg
 #   name: Secure Mail Gateway
@@ -270,19 +270,19 @@ components:
 #   name: Volume Backup Service
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: vpc
   name: Virtual Private Cloud
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: vpcep
   name: VPC Endpoint
 
 - attributes:
-    category: Networking
+    category: Network
     region: EU-CH2
     type: vpn
   name: Virtual Private Network

--- a/sdb_prod/catalog.yaml
+++ b/sdb_prod/catalog.yaml
@@ -100,12 +100,12 @@ components:
     type: cts
   name: Cloud Trace Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: dc
   name: Direct Connect
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: dc
   name: Direct Connect
@@ -160,12 +160,12 @@ components:
     type: dms
   name: Distributed Message Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: dns
   name: Domain Name Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: dns
   name: Domain Name Service
@@ -195,22 +195,22 @@ components:
     type: ecs
   name: Elastic Cloud Server
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: eip
   name: Elastic IP
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: eip
   name: Elastic IP
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: elb
   name: Elastic Load Balancing
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: elb
   name: Elastic Load Balancing
@@ -280,12 +280,12 @@ components:
     type: mrs
   name: Map Reduce Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: natgw
   name: NAT Gateway
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: natgw
   name: NAT Gateway
@@ -300,15 +300,15 @@ components:
     type: obs
   name: Object Storage Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: plas
-  name: Private Link Access
+  name: Private Link Access Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: plas
-  name: Private Link Access
+  name: Private Link Access Service
 - attributes:
     category: Database
     region: EU-DE
@@ -370,12 +370,12 @@ components:
     type: smn
   name: Simple Message Notification
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: smg
   name: Secure Mail Gateway
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: smg
   name: Secure Mail Gateway
@@ -410,32 +410,32 @@ components:
     type: vbs
   name: Volume Backup Service
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: vpc
   name: Virtual Private Cloud
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: vpc
   name: Virtual Private Cloud
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: vpcep
   name: VPC Endpoint
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: vpcep
   name: VPC Endpoint
 - attributes:
-    category: Networking
+    category: Network
     region: EU-DE
     type: vpn
   name: Virtual Private Network
 - attributes:
-    category: Networking
+    category: Network
     region: EU-NL
     type: vpn
   name: Virtual Private Network


### PR DESCRIPTION
Hi all, 
On SD2, Category "Networking"  should be renamed to "Network",
and also attributes name "Private Link Access" should be named "Private Link Access Service"
According to documentation and e-mail request from Stefan-Adrian.    
https://docs.sc.otc.t-systems.com/network.html
https://docs.sc.otc.t-systems.com/docsportal/additional/glossary.html
Br,
Elvis