### PR TITLE
Cts v1 removal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,7 +109,6 @@ matrix:
           - compute
           - csbs
           - css
-          - cts_v1
           - cts_v2
           - cts_v3
           - dataarts
@@ -195,7 +194,6 @@ matrix:
           - ces_skip_v1
           - compute
           - css
-          - cts_v1
           - cts_v2
           - cts_v3
           - database_skip
@@ -259,7 +257,6 @@ matrix:
           - compute
           - csbs
           - css
-          - cts_v1
           - cts_v2
           - cts_v3
           - dataarts
@@ -335,7 +332,6 @@ matrix:
           - ces_skip_v1
           - compute
           - css
-          - cts_v1
           - cts_v2
           - cts_v3
           - database_skip

--- a/config.yaml
+++ b/config.yaml
@@ -109,6 +109,7 @@ matrix:
           - compute
           - csbs
           - css
+          - cts_skip_v1
           - cts_v2
           - cts_v3
           - dataarts
@@ -194,6 +195,7 @@ matrix:
           - ces_skip_v1
           - compute
           - css
+          - cts_skip_v1
           - cts_v2
           - cts_v3
           - database_skip
@@ -257,6 +259,7 @@ matrix:
           - compute
           - csbs
           - css
+          - cts_skip_v1
           - cts_v2
           - cts_v3
           - dataarts
@@ -332,6 +335,7 @@ matrix:
           - ces_skip_v1
           - compute
           - css
+          - cts_skip_v1
           - cts_v2
           - cts_v3
           - database_skip

--- a/epmon/config.yaml
+++ b/epmon/config.yaml
@@ -97,11 +97,6 @@ elements:
     service_type: ctsv2
     sdk_proxy: cts
     urls: []
-  cts_v1:
-    service_type: cts
-    sdk_proxy: cts
-    urls:
-      - /tracker?tracker_name=system
   cts_v2:
     service_type: ctsv2
     sdk_proxy: ctsv2

--- a/epmon/config.yaml
+++ b/epmon/config.yaml
@@ -93,6 +93,10 @@ elements:
     service_type: cts
     sdk_proxy: cts
     urls: []
+  cts_skip_v1:
+    service_type: cts
+    sdk_proxy: cts
+    urls: []
   cts_skip_v2:
     service_type: ctsv2
     sdk_proxy: cts

--- a/mp-prod/conf.d/flag_metrics.yaml
+++ b/mp-prod/conf.d/flag_metrics.yaml
@@ -195,31 +195,6 @@ flag_metrics:
       - name: "production_eu-nl"
 
   ### CTS
-  # API version 1
-  - name: "api_down"
-    service: "cts"
-    template:
-      name: "api_down"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
-  - name: "api_slow"
-    service: "cts"
-    template:
-      name: "api_slow"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
-  - name: "api_success_rate_low"
-    service: "cts"
-    template:
-      name: "api_success_rate_low"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
   # API version 2
   - name: "api_down"
     service: "ctsv2"

--- a/mp-prod/conf.d/health_metrics.yaml
+++ b/mp-prod/conf.d/health_metrics.yaml
@@ -461,9 +461,6 @@ health_metrics:
     component_name: "Cloud Trace Service"
     category: management
     metrics:
-      - cts.api_slow
-      - cts.api_down
-      - cts.api_success_rate_low
       - ctsv2.api_slow
       - ctsv2.api_down
       - ctsv2.api_success_rate_low
@@ -471,9 +468,9 @@ health_metrics:
       - ctsv3.api_down
       - ctsv3.api_success_rate_low
     expressions:
-      - expression: "cts.api_slow || cts.api_success_rate_low || ctsv2.api_slow || ctsv2.api_success_rate_low || ctsv3.api_slow || ctsv3.api_success_rate_low"
+      - expression: "ctsv2.api_slow || ctsv2.api_success_rate_low || ctsv3.api_slow || ctsv3.api_success_rate_low"
         weight: 1
-      - expression: "cts.api_down || ctsv2.api_down || ctsv3.api_down"
+      - expression: "ctsv2.api_down || ctsv3.api_down"
         weight: 2
   ### Enterprise-Dashboard
   enterprise-dashboard:


### PR DESCRIPTION
Removing CTS v1 checks from SD2, since they are outdated