### PR TITLE
Removing Flavors API from epmon

### DIFF
--- a/epmon/config.yaml
+++ b/epmon/config.yaml
@@ -206,7 +206,6 @@ elements:
     urls:
       - /cloudservers/detail
       - /cloudservers/limits
-      - /cloudservers/flavors
       - /cloudservers/tags
   eipv2.0:
     service_type: vpc


### PR DESCRIPTION
This API  is taking often more than 5 seconds to respond and until there's improvement in the API it will be removed from epmon