### PR TITLE
Cts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ matrix:
           - csbs
           - css
           - cts_skip_v1
-          - cts_v2
+          - cts_skip_v2
           - cts_v3
           - dataarts
           - database_skip
@@ -203,7 +203,7 @@ matrix:
           - compute
           - css
           - cts_skip_v1
-          - cts_v2
+          - cts_skip_v2
           - cts_v3
           - database_skip
           - dcaas
@@ -273,7 +273,7 @@ matrix:
           - csbs
           - css
           - cts_skip_v1
-          - cts_v2
+          - cts_skip_v2
           - cts_v3
           - dataarts
           - database_skip
@@ -358,7 +358,7 @@ matrix:
           - compute
           - css
           - cts_skip_v1
-          - cts_v2
+          - cts_skip_v2
           - cts_v3
           - database_skip
           - dcaas

--- a/epmon/config.yaml
+++ b/epmon/config.yaml
@@ -109,16 +109,13 @@ elements:
     service_type: ctsv2
     sdk_proxy: cts
     urls: []
-  cts_v2:
-    service_type: ctsv2
-    sdk_proxy: ctsv2
-    urls:
-      - /system/trace?limit=10
   cts_v3:
     service_type: ctsv3
     sdk_proxy: ctsv3
     urls:
       - /notifications/smn
+      - /trackers
+      - /traces
   cts_v3_swiss:
     service_type: ctsv3
     sdk_proxy: ctsv3

--- a/mp-prod/conf.d/flag_metrics.yaml
+++ b/mp-prod/conf.d/flag_metrics.yaml
@@ -217,36 +217,11 @@ flag_metrics:
       - name: "production_eu-nl"
 
   ### CTS
-  # API version 2
-  - name: "api_down"
-    service: "ctsv2"
-    template:
-      name: "api_down"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
-  - name: "api_slow"
-    service: "ctsv2"
-    template:
-      name: "api_slow"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
-  - name: "api_success_rate_low"
-    service: "ctsv2"
-    template:
-      name: "api_success_rate_low"
-    environments:
-      - name: "production_eu-de"
-      - name: "production_eu-nl"
-
   # API version 3
-  - name: "api_down"
+  - name: "api_down_3min"
     service: "ctsv3"
     template:
-      name: "api_down"
+      name: "api_down_3min"
     environments:
       - name: "production_eu-de"
       - name: "production_eu-nl"

--- a/mp-prod/conf.d/health_metrics.yaml
+++ b/mp-prod/conf.d/health_metrics.yaml
@@ -503,16 +503,13 @@ health_metrics:
     component_name: "Cloud Trace Service"
     category: management
     metrics:
-      - ctsv2.api_slow
-      - ctsv2.api_down
-      - ctsv2.api_success_rate_low
       - ctsv3.api_slow
-      - ctsv3.api_down
+      - ctsv3.api_down_3min
       - ctsv3.api_success_rate_low
     expressions:
-      - expression: "ctsv2.api_slow || ctsv2.api_success_rate_low || ctsv3.api_slow || ctsv3.api_success_rate_low"
+      - expression: "ctsv3.api_slow || ctsv3.api_success_rate_low"
         weight: 1
-      - expression: "ctsv2.api_down || ctsv3.api_down"
+      - expression: "ctsv3.api_down_3min"
         weight: 2
   ### Enterprise-Dashboard
   enterprise-dashboard:


### PR DESCRIPTION
This modification based on our meeting today. Since v3 is the supported one, we remove v2 API, extend it with the new URLs/APIs and since v3 can have spikes in response, I've changed the api_down metric to 3 minutes from 1.